### PR TITLE
Fix ByteRate always being zero

### DIFF
--- a/riffwave.js
+++ b/riffwave.js
@@ -103,7 +103,7 @@ var RIFFWAVE = function(data) {
   this.Make = function(data) {
     if (data instanceof Array) this.data = data;
     this.header.blockAlign = (this.header.numChannels * this.header.bitsPerSample) >> 3;
-    this.header.byteRate = this.header.blockAlign * this.sampleRate;
+    this.header.byteRate = this.header.blockAlign * this.header.sampleRate;
     this.header.subChunk2Size = this.data.length * (this.header.bitsPerSample >> 3);
     this.header.chunkSize = 36 + this.header.subChunk2Size;
 


### PR DESCRIPTION
jsfxr is currently outputting slightly invalid wav files due a typo in `riffwav.js`. This PR fixes that.

Most audio tools seem to read them just fine, but I'm over here because they don't currently work in the [bevy game engine](https://github.com/bevyengine/bevy), which ultimately depends on [hound](https://github.com/ruuda/hound) to do wav decoding.