### PR TITLE
List sfxr.js and riffwave.js in the module exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.2.1",
   "description": "8-bit sound effects generator based on sfxr",
   "main": "sfxr.js",
+  "exports": [
+    "./sfxr.js",
+    "./riffwave.js"
+  ],
   "homepage": "https://github.com/chr15m/jsfxr",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This was needed for me for the module to be compiled properly with my build system (webpack). Otherwise it can't find riffwave.

Let me know if I should also bump the version number. Might be needed for npm to pick this up I guess?