### PR TITLE
Add the ability to save and upload JSON saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,13 +36,16 @@ function gen(fx) {
   PARAMS.sound_vol = SOUND_VOL;
   PARAMS.sample_rate = SAMPLE_RATE;
   PARAMS.sample_size = SAMPLE_SIZE;
+  var name;
   if (fx.indexOf("#") == 0) {
     PARAMS.fromB58(fx.slice(1));
-    $("#wav").text("random.wav").attr("download", "random.wav");
+    name = "random";
   } else {
     PARAMS[fx]();
-    $("#wav").text(fx + ".wav").attr("download", fx + ".wav");
+    name = fx;
   }
+  $("#wav").text(name + ".wav").attr("download", name + ".wav");
+  $("#json").text(name + ".json").attr("download", name + ".json");
   updateUi();
   play();
 }
@@ -70,7 +73,8 @@ function play(noregen) {
       $("#clipping").text(SOUND.clipping);
     }
     
-    $("#wav").attr("href", SOUND.dataURI)  ;
+    $("#wav").attr("href", SOUND.dataURI);
+    $("#json").attr("href", 'data:text/plain;charset=UTF-8,' + encodeURIComponent(serialize_params_to_string()));
     $("#sfx").attr("href", "sfx.wav?" + PARAMS.query());
     
     SOUND.getAudio().play();
@@ -85,16 +89,43 @@ function copy() {
   b.css("display", "none");
 }
 
+function serialize_params_to_string() {
+  return JSON.stringify(PARAMS, null, 2);
+}
+
 function serialize_params() {
-  $("textarea").val(JSON.stringify(PARAMS, null, 2));
+  $("textarea").val(serialize_params_to_string());
   $("#serialize").show();
 }
 
-function deserialize_params() {
-  var newPARAMS = JSON.parse($("textarea").val());
+function deserialize_params_from_string(json_string) {
+  var newPARAMS = JSON.parse(json_string);
   PARAMS.fromJSON(newPARAMS);
   play();
   updateUi();
+}
+
+function deserialize_params() {
+  deserialize_params_from_string($("textarea").val());
+}
+
+function upload_params_from_file() {
+  $("#open_save_impl").click();
+}
+
+function on_upload_file_selected(e) {
+  var file = e.target.files[0];
+  if (!file) {
+    return;
+  }
+  var reader = new FileReader();
+  reader.onload = function(e) {
+    var contents = e.target.result;
+    $("textarea").val(contents);
+    deserialize_params_from_string(contents);
+    $("#open_save_impl").val("");
+  };
+  reader.readAsText(file);
 }
 
 function disenable() {
@@ -212,7 +243,7 @@ button, #soundexport, #sound_vol {
   width: 80px;
 }
 
-#wav {
+#wav, #json {
   font-weight: bold;
 }
 
@@ -349,6 +380,10 @@ a {
   margin-top: 1em;
 }
 
+/*#open_save_impl {
+  display: none;
+}*/
+
 </script>
 
 </style>
@@ -441,6 +476,8 @@ a {
   <button onclick="play(true)">Play</button><br/>
   <p id="soundexport">
   Download:</br><a id="wav">sfx.wav</a> <br/>
+  <br/>
+  Save As:</br><a id="json">sfx.json</a> <br/>
   <!-- <a id="permalink"></a> -->
   <!-- <a id="sfx">sfx.wav</a><br/> -->
 
@@ -487,6 +524,8 @@ a {
 <div id="data">
   <button onclick="serialize_params();"> ▼ Serialize</button>
   <button onclick="deserialize_params()"> ▲ Deserialize</button>
+  <button onclick="upload_params_from_file()"> ⇧ Open Save</button>
+  <input type="file" id="open_save_impl" accept="application/JSON" onchange="on_upload_file_selected.apply(this, arguments)" />
   <div id="serialize">
     <textarea></textarea>
     <button onclick="$('textarea').select(); document.execCommand('copy');">Copy</button>

--- a/index.html
+++ b/index.html
@@ -380,9 +380,9 @@ a {
   margin-top: 1em;
 }
 
-/*#open_save_impl {
+#open_save_impl {
   display: none;
-}*/
+}
 
 </script>
 


### PR DESCRIPTION
While you can serialize and deserialize the JSON content, it's a hassle to `copy text -> create new text file -> paste -> save as...` or `open file on computer -> copy -> serialize -> paste -> deserialize`.

This PR adds an option under "Download" to "Save As..." to conveniently save the current settings as a `.json` file on the user's computer.

There is also a new `Open Save` button that can upload the contents of a `.json` file from the user's computer instantly!

![W7afYOv8T5](https://github.com/user-attachments/assets/0832568d-fa3e-4257-a474-c2af5d3c00d4)
