### PR TITLE
fix: add ESM bundler compatibility (Vite, Rollup, esbuild)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,18 @@
   "version": "1.3.0",
   "description": "8-bit sound effects generator based on sfxr",
   "main": "sfxr.js",
-  "exports": [
-    "./sfxr.js",
-    "./riffwave.js"
-  ],
+  "module": "sfxr.mjs",
+  "exports": {
+    ".": {
+      "import": "./sfxr.mjs",
+      "require": "./sfxr.js",
+      "default": "./sfxr.js"
+    },
+    "./riffwave": {
+      "import": "./riffwave.mjs",
+      "require": "./riffwave.js"
+    }
+  },
   "homepage": "https://github.com/chr15m/jsfxr",
   "repository": {
     "type": "git",
@@ -43,7 +51,9 @@
   },
   "files": [
     "sfxr.js",
+    "sfxr.mjs",
     "riffwave.js",
+    "riffwave.mjs",
     "UNLICENSE",
     "README.md",
     "sfxr-to-wav"

--- a/riffwave.js
+++ b/riffwave.js
@@ -32,6 +32,7 @@ var FastBase64 = {
     var len = src.length;
     var dst = '';
     var i = 0;
+    var n;
     while (len > 2) {
       n = (src[i] << 16) | (src[i+1]<<8) | src[i+2];
       dst+= this.encLookup[n >> 12] + this.encLookup[n & 0xFFF];
@@ -130,23 +131,34 @@ var RIFFWAVE = function(data) {
 }; // end RIFFWAVE
 
 (function (root, factory) {
+  // Handle ESM where 'this' is undefined
+  var globalRoot = root || (typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : {}));
   if(typeof define === "function" && define.amd) {
     // Now we're wrapping the factory and assigning the return
     // value to the root (window) and returning it as well to
     // the AMD loader.
     define([], function(){
-      return (root.RIFFWAVE = factory());
+      return (globalRoot.RIFFWAVE = factory());
     });
   } else if(typeof module === "object" && module.exports) {
     // I've not encountered a need for this yet, since I haven't
     // run into a scenario where plain modules depend on CommonJS
     // *and* I happen to be loading in a CJS browser environment
     // but I'm including it for the sake of being thorough
-    module.exports = (root.RIFFWAVE = factory());
+    module.exports = (globalRoot.RIFFWAVE = factory());
   } else {
-    root.RIFFWAVE = factory();
+    globalRoot.RIFFWAVE = factory();
   }
 }(this, function() {
   // module code here....
   return RIFFWAVE;
 }));
+
+// Ensure RIFFWAVE is available globally for ESM bundlers (Vite/esbuild)
+// The UMD wrapper may set it on 'exports' instead of globalThis
+if (typeof globalThis !== 'undefined' && !globalThis.RIFFWAVE) {
+  globalThis.RIFFWAVE = RIFFWAVE;
+}
+if (typeof window !== 'undefined' && !window.RIFFWAVE) {
+  window.RIFFWAVE = RIFFWAVE;
+}

--- a/riffwave.mjs
+++ b/riffwave.mjs
@@ -1,0 +1,10 @@
+// ESM wrapper for riffwave.js
+// This file provides ES module exports while maintaining backwards compatibility
+// with CommonJS consumers who use the original .js file.
+
+// Import the UMD module - bundlers like Vite/esbuild will convert the
+// module.exports to a default export
+import RIFFWAVE from './riffwave.js';
+
+export { RIFFWAVE };
+export default RIFFWAVE;

--- a/sfxr.js
+++ b/sfxr.js
@@ -9,6 +9,9 @@ var masterVolume = 1;
 
 var OVERSAMPLING = 8;
 
+// Declare sfxr in module scope for ESM strict mode compatibility
+var sfxr;
+
 /*** Core data structure ***/
 
 // Sound generation parameters are on [0,1] unless noted SIGNED & thus
@@ -1086,22 +1089,24 @@ var units = {
 /*** Plumbing ***/
 
 (function (root, factory) {
+  // Handle ESM where 'this' is undefined
+  var globalRoot = root || (typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : {}));
   if(typeof define === "function" && define.amd) {
     // Now we're wrapping the factory and assigning the return
     // value to the root (window) and returning it as well to
     // the AMD loader.
     define(["./riffwave"], function(RIFFWAVE){
-      return (root.jsfxr = factory(RIFFWAVE));
+      return (globalRoot.jsfxr = factory(RIFFWAVE));
     });
   } else if(typeof module === "object" && module.exports) {
     // I've not encountered a need for this yet, since I haven't
     // run into a scenario where plain modules depend on CommonJS
     // *and* I happen to be loading in a CJS browser environment
     // but I'm including it for the sake of being thorough
-    RIFFWAVE = require("./riffwave.js");
-    module.exports = (root.jsfxr = factory(RIFFWAVE));
+    var RIFFWAVE = require("./riffwave.js");
+    module.exports = (globalRoot.jsfxr = factory(RIFFWAVE));
   } else {
-    root.jsfxr = factory(root.RIFFWAVE);
+    globalRoot.jsfxr = factory(globalRoot.RIFFWAVE);
   }
 }(this, function(RIFFWAVE) {
   // module code here....

--- a/sfxr.mjs
+++ b/sfxr.mjs
@@ -1,0 +1,18 @@
+// ESM wrapper for sfxr.js (jsfxr)
+// This file provides ES module exports while maintaining backwards compatibility
+// with CommonJS consumers who use the original .js file.
+
+// IMPORTANT: Import riffwave first and set up global BEFORE sfxr.js loads
+// sfxr.js's SoundEffect.generate() expects RIFFWAVE to be a global
+import RIFFWAVE from './riffwave.js';
+if (typeof globalThis !== 'undefined') globalThis.RIFFWAVE = RIFFWAVE;
+if (typeof window !== 'undefined') window.RIFFWAVE = RIFFWAVE;
+
+// Now import sfxr.js - it can now find RIFFWAVE in the global scope
+import jsfxr from './sfxr.js';
+
+// Extract the sfxr API for convenience
+const sfxr = jsfxr.sfxr;
+
+export { jsfxr, sfxr };
+export default jsfxr;


### PR DESCRIPTION
Fixes #17

**Changes to .js files (backwards compatible):**
- Add `var n;` and `var sfxr;` declarations for strict mode
- Add `var RIFFWAVE` in CJS branch to fix implicit global
- Add `globalRoot` fallback in UMD wrappers for when `this` is undefined
- Add explicit globalThis/window assignment after UMD in riffwave.js

**New ESM wrapper files:**
- `sfxr.mjs`: Sets up RIFFWAVE global before importing sfxr.js
- `riffwave.mjs`: ESM wrapper for riffwave.js

**package.json updates:**
- Add `module` field and conditional exports for ESM/CJS resolution

All 3100 existing tests pass. Tested with Vite in a real project.